### PR TITLE
feat: 스피드 아이템 구현

### DIFF
--- a/Source/Project8/Private/ItemBase.cpp
+++ b/Source/Project8/Private/ItemBase.cpp
@@ -50,10 +50,11 @@ void AItemBase::OnItemEndOverlap(
 
 void AItemBase::ActivateItem(AActor* Activator)
 {
-	if (PickupParticle)
+	UWorld* World = GetWorld();
+	if (World && PickupParticle)
 	{
 		UParticleSystemComponent* SpawnedParticle = UGameplayStatics::SpawnEmitterAtLocation(
-			GetWorld(),
+			World,
 			PickupParticle,
 			GetActorLocation(),
 			GetActorRotation(),
@@ -66,7 +67,7 @@ void AItemBase::ActivateItem(AActor* Activator)
 				ParticleTimerHandle,
 				[SpawnedParticle]()
 				{
-					if (SpawnedParticle)
+					if (IsValid(SpawnedParticle))
 					{
 						SpawnedParticle->DestroyComponent();
 					}
@@ -77,9 +78,9 @@ void AItemBase::ActivateItem(AActor* Activator)
 		}
 	}
 
-	if (PickupSound)
+	if (World && PickupSound)
 	{
-		UGameplayStatics::PlaySoundAtLocation(GetWorld(), PickupSound, GetActorLocation());
+		UGameplayStatics::PlaySoundAtLocation(World, PickupSound, GetActorLocation());
 	}
 }
 

--- a/Source/Project8/Private/SlowItem.cpp
+++ b/Source/Project8/Private/SlowItem.cpp
@@ -1,0 +1,23 @@
+#include "SlowItem.h"
+#include "Project8Character.h"
+
+ASlowItem::ASlowItem()
+{
+	ItemType = "SpeedItem";
+	Amount = 20.f;
+	Duration = 5.f;
+}
+
+void ASlowItem::ActivateItem(AActor* Activator)
+{
+	Super::ActivateItem(Activator);
+	if (Activator && Activator->ActorHasTag("Player"))
+	{
+		if (AProject8Character* PlayerCharacter = Cast<AProject8Character>(Activator))
+		{
+			Amount = FMath::RandRange(-300.f, 300.f);
+			PlayerCharacter->ApplySlowEffect(Amount, Duration);
+		}
+		DestroyItem();
+	}
+}

--- a/Source/Project8/Project8Character.h
+++ b/Source/Project8/Project8Character.h
@@ -6,6 +6,7 @@
 
 class UWidgetComponent;
 DECLARE_DYNAMIC_MULTICAST_DELEGATE_OneParam(FOnHealthChangedSignature, float, ChangedAmount);
+DECLARE_DYNAMIC_MULTICAST_DELEGATE_OneParam(FOnSlowStatusChangedSignature, bool, bIsSlowed);
 
 UCLASS(abstract)
 class AProject8Character : public ACharacter
@@ -19,6 +20,12 @@ private:
 	UPROPERTY(VisibleAnywhere, BlueprintReadOnly, Category = Camera, meta = (AllowPrivateAccess = "true"))
 	class USpringArmComponent* CameraBoom;
 
+	void RestoreMovementSpeed();
+
+	FTimerHandle TimerHandle_SlowEffect;
+	
+	float OriginalWalkSpeed;
+	
 protected:
 	
 	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Health")
@@ -41,6 +48,12 @@ public:
 	UPROPERTY(EditAnywhere, BlueprintReadOnly, Category = "UI")
 	UWidgetComponent* OverheadWidget;
 	
+	UPROPERTY(BlueprintAssignable, Category = "Events")
+	FOnSlowStatusChangedSignature OnSlowStatusChanged;
+	
+	UFUNCTION(BlueprintPure, Category = "Status")
+	float GetSlowEffectRemainingTime() const;
+	
 	UFUNCTION(BlueprintPure, Category = "Health")
 	int32 GetHealth() const;
 	
@@ -49,6 +62,9 @@ public:
 	
 	UFUNCTION(BlueprintCallable, Category = "Health")
 	void AddHealth(float Amount);
+	
+	UFUNCTION(BlueprintCallable, Category = "Speed")
+    void ApplySlowEffect(float SlowAmount, float Duration);
 	
 	UPROPERTY(BlueprintAssignable, Category = "Events")
 	FOnHealthChangedSignature OnHealthChanged;

--- a/Source/Project8/Public/SlowItem.h
+++ b/Source/Project8/Public/SlowItem.h
@@ -1,0 +1,23 @@
+#pragma once
+
+#include "CoreMinimal.h"
+#include "ItemBase.h"
+#include "SlowItem.generated.h"
+
+UCLASS()
+class PROJECT8_API ASlowItem : public AItemBase
+{
+	GENERATED_BODY()
+
+public:
+	ASlowItem();
+	
+	virtual void ActivateItem(AActor* Activator) override;
+	
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Item")
+	int32 Amount;
+
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Item")
+	int32 Duration;
+	
+};


### PR DESCRIPTION
SlowItem(ItemBase 클래스) 생성
- 아이템을 먹으면 CharacterMovement -> MaxWalkSpeed 를 Amount 만큼 조정
- Amount 는 FMath::RandRange 함수로 -300 에서 300 사이 수 랜덤 설정
- Duration 동안 효과가 지속되는데 이 때, 화면 좌측 하단에 관련 아이콘과 남은 지속 시간이 표시됨
- 해당 아이템은 2레벨 맵부터 등장

2-3 레벨에 SpawnVolume 배치하여 랜덤 아이템 스폰
