### PR TITLE
feat: 필드 스파이크 장애물 추가

### DIFF
--- a/Source/Project8/Private/MyGameInstance.cpp
+++ b/Source/Project8/Private/MyGameInstance.cpp
@@ -4,6 +4,7 @@ UMyGameInstance::UMyGameInstance()
 {
 	TotalScore = 0;
 	CurrentLevelIndex = 0;
+	CharacterHealth = 100.f;
 }
 
 void UMyGameInstance::AddToScore(int32 Amount)

--- a/Source/Project8/Private/MyGameState.cpp
+++ b/Source/Project8/Private/MyGameState.cpp
@@ -2,6 +2,7 @@
 #include "MyGameInstance.h"
 #include "SpawnVolume.h"
 #include "CoinItem.h"
+#include "Project8Character.h"
 #include "Project8PlayerController.h"
 
 #include "Kismet/GameplayStatics.h"
@@ -73,6 +74,21 @@ void AMyGameState::StartWave()
 			}
 		}
 	}
+	if (CurrentWave > 1)
+	{
+		if (SpikeItemClass && FoundVolumes.Num() > 0)
+		{
+			ASpawnVolume* SpawnVolume = Cast<ASpawnVolume>(FoundVolumes[0]);
+			if (SpawnVolume)
+			{
+				int SpikeCount = (CurrentWave - 1) * 9;
+				for (int i = 0; i < SpikeCount; ++i)
+				{
+					SpawnVolume->SpawnItem(SpikeItemClass);
+				}
+			}
+		}
+	}
 
 	GetWorldTimerManager().SetTimer(
 	   WaveTimerHandle,
@@ -115,6 +131,12 @@ void AMyGameState::StartLevel()
 		{
 			Score = MyGameInstance->TotalScore;
 			CurrentLevelIndex = MyGameInstance->CurrentLevelIndex;
+			
+			AProject8Character* PlayerCharacter = Cast<AProject8Character>(GetWorld()->GetFirstPlayerController()->GetPawn());
+			if (PlayerCharacter)
+			{
+				PlayerCharacter->SetHealth(MyGameInstance->CharacterHealth);
+			}
 		}
 	}
 }
@@ -131,6 +153,12 @@ void AMyGameState::EndLevel()
 			AddScore(Score);
 			CurrentLevelIndex++;
 			MyGameInstance->CurrentLevelIndex = CurrentLevelIndex;
+
+			AProject8Character* PlayerCharacter = Cast<AProject8Character>(GetWorld()->GetFirstPlayerController()->GetPawn());
+			if (PlayerCharacter)
+			{
+				MyGameInstance->CharacterHealth = PlayerCharacter->GetHealth();
+			}
 		}
 		
 	}

--- a/Source/Project8/Private/SpawnVolume.cpp
+++ b/Source/Project8/Private/SpawnVolume.cpp
@@ -22,7 +22,7 @@ FVector ASpawnVolume::GetRandomPointInVolume() const
 	return BoxOrigin + FVector(
 		FMath::RandRange(-BoxExtent.X, BoxExtent.X),
 		FMath::RandRange(-BoxExtent.Y, BoxExtent.Y),
-		FMath::RandRange(-BoxExtent.Z, BoxExtent.Z));
+		BoxExtent.Z);
 }
 
 FItemSpawnRow* ASpawnVolume::GetRandomItem() const

--- a/Source/Project8/Private/Spike.cpp
+++ b/Source/Project8/Private/Spike.cpp
@@ -1,0 +1,102 @@
+#include "Spike.h"
+#include "GameFramework/Character.h"
+#include "Components/SphereComponent.h"
+#include "GameFramework/RotatingMovementComponent.h"
+#include "Kismet/GameplayStatics.h"
+
+ASpike::ASpike()
+{
+	ItemType = "Spike";
+
+	SpikeDamage = 15;
+	SpikeRadius = 100;
+	VisibleDuration = 3.f;
+	HiddenDuration = 1.2f;
+
+	bIsActivating = false;
+	bIsDamaged = false;
+
+	Mesh->SetCollisionProfileName(FName("NoCollision"));
+	
+	DamageCollision = CreateDefaultSubobject<USphereComponent>(TEXT("ExplosionCollision"));
+	DamageCollision->InitSphereRadius(SpikeRadius);
+	DamageCollision->SetCollisionProfileName(TEXT("OverlapAllDynamic"));
+	DamageCollision->SetupAttachment(Root);
+
+	RotatingMovementComp->RotationRate = FRotator::ZeroRotator;
+
+}
+
+void ASpike::BeginPlay()
+{
+	Super::BeginPlay();
+
+	Disappear();
+}
+void ASpike::OnItemEndOverlap(UPrimitiveComponent* OverlappedComp, AActor* OtherActor, UPrimitiveComponent* OtherComp,
+                              int32 OtherBodyIndex)
+{
+	Super::OnItemEndOverlap(OverlappedComp, OtherActor, OtherComp, OtherBodyIndex);
+	bIsDamaged = false;
+}
+
+void ASpike::Disappear()
+{
+	SetActorHiddenInGame(true);
+	SetActorEnableCollision(false);
+
+	bIsActivating = false;
+	bIsDamaged = false;
+
+	GetWorld()->GetTimerManager().SetTimer(
+		VisibleTimerHandle,
+		this,
+		&ASpike::Appear,
+		HiddenDuration
+		);
+}
+
+void ASpike::Appear()
+{
+	SetActorHiddenInGame(false);
+	SetActorEnableCollision(true);
+	
+	bIsActivating = true;
+
+	TArray<AActor*> OverlappingActors;
+	DamageCollision->GetOverlappingActors(OverlappingActors, TSubclassOf<ACharacter>(ACharacter::StaticClass()));
+
+	for (AActor* OverlappingActor : OverlappingActors)
+	{
+		ActivateItem(OverlappingActor);
+	}
+
+	GetWorld()->GetTimerManager().SetTimer(
+		VisibleTimerHandle,
+		this,
+		&ASpike::Disappear,
+		VisibleDuration
+		);
+}
+
+void ASpike::ActivateItem(AActor* Activator)
+{
+	Super::ActivateItem(Activator);
+	
+	if (Activator && Activator->ActorHasTag("Player"))
+	{
+		if (!bIsDamaged && bIsActivating)
+		{
+			bIsDamaged = true;
+			
+			UGameplayStatics::ApplyDamage(
+				Activator,
+				SpikeDamage,
+				nullptr,
+				this,
+				UDamageType::StaticClass()
+			);
+		}
+	}
+}
+

--- a/Source/Project8/Project8Character.cpp
+++ b/Source/Project8/Project8Character.cpp
@@ -74,6 +74,11 @@ int32 AProject8Character::GetHealth() const
 	return Health;
 }
 
+void AProject8Character::SetHealth(float NewHealth)
+{
+	Health = NewHealth;
+}
+
 int32 AProject8Character::GetMaxHealthBP() const
 {
 	return MaxHealth;

--- a/Source/Project8/Project8Character.h
+++ b/Source/Project8/Project8Character.h
@@ -65,6 +65,9 @@ public:
 	UFUNCTION(BlueprintPure, Category = "Health")
 	int32 GetHealth() const;
 	
+	UFUNCTION(BlueprintCallable, Category = "Health")
+	void SetHealth(float NewHealth);
+	
 	UFUNCTION(BlueprintPure, Category = "Health")
 	int32 GetMaxHealthBP() const;
 	

--- a/Source/Project8/Project8PlayerController.cpp
+++ b/Source/Project8/Project8PlayerController.cpp
@@ -1,20 +1,13 @@
 #include "Project8PlayerController.h"
 #include "GameFramework/Pawn.h"
 #include "Blueprint/AIBlueprintHelperLibrary.h"
-#include "Blueprint/UserWidget.h"
-#include "NiagaraSystem.h"
 #include "NiagaraFunctionLibrary.h"
 #include "Project8Character.h"
 #include "Engine/World.h"
 #include "EnhancedInputComponent.h"
-#include "InputActionValue.h"
 #include "EnhancedInputSubsystems.h"
 #include "Engine/LocalPlayer.h"
-
 #include "MyGameInstance.h"
-#include "MyGameState.h"
-#include "Blueprint/UserWidget.h"
-#include "Components/TextBlock.h"
 #include "Kismet/GameplayStatics.h"
 
 DEFINE_LOG_CATEGORY(LogTemplateCharacter);
@@ -31,6 +24,7 @@ AProject8PlayerController::AProject8PlayerController()
 	DefaultMouseCursor = EMouseCursor::Default;
 	CachedDestination = FVector::ZeroVector;
 	FollowTime = 0.f;
+
 }
 
 float AProject8PlayerController::GetReverseEffectRemainingTime() const
@@ -41,8 +35,7 @@ float AProject8PlayerController::GetReverseEffectRemainingTime() const
 void AProject8PlayerController::BeginPlay()
 {
 	Super::BeginPlay();
-
-    
+	
 	FString CurrentMapName = GetWorld()->GetMapName();
 	if (CurrentMapName.Contains(TEXT("BasicMap")))
 	{
@@ -61,7 +54,7 @@ void AProject8PlayerController::StartGame()
 		MyGameInstance->CurrentLevelIndex = 0;
 	}
 	SetGameInputMode();
-	UGameplayStatics::OpenLevel(GetWorld(), TEXT("BasicLevel"));
+	UGameplayStatics::OpenLevel(GetWorld(), TEXT("AdvancedLevel"));
 }
 
 UMenuComponent* AProject8PlayerController::GetMenuComponent() const

--- a/Source/Project8/Project8PlayerController.h
+++ b/Source/Project8/Project8PlayerController.h
@@ -9,6 +9,7 @@
 class UNiagaraSystem;
 class UInputMappingContext;
 class UInputAction;
+class UAudioComponent;
 
 DECLARE_LOG_CATEGORY_EXTERN(LogTemplateCharacter, Log, All);
 

--- a/Source/Project8/Public/MyGameInstance.h
+++ b/Source/Project8/Public/MyGameInstance.h
@@ -16,8 +16,12 @@ public:
 	
 	UPROPERTY(VisibleAnywhere, BlueprintReadWrite, Category = "GameData")
 	int32 CurrentLevelIndex;
-
+	
+	UPROPERTY(VisibleAnywhere, BlueprintReadWrite, Category = "GameData")
+	float CharacterHealth;
+	
 	UFUNCTION(BlueprintCallable, Category = "GameData")
 	void AddToScore(int32 Amount);
+
 	
 };

--- a/Source/Project8/Public/MyGameState.h
+++ b/Source/Project8/Public/MyGameState.h
@@ -50,6 +50,9 @@ public:
 	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Level")
 	TArray<FName> LevelNames;
 	
+	UPROPERTY(EditDefaultsOnly, Category = "Spawning")
+	TSubclassOf<AActor> SpikeItemClass;
+	
 	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Score")
 	int32 Score;
 

--- a/Source/Project8/Public/SpawnVolume.h
+++ b/Source/Project8/Public/SpawnVolume.h
@@ -18,6 +18,7 @@ public:
 	UFUNCTION(BlueprintCallable, Category = "Spawn Volume")
 	AActor* SpawnRandomItem();
 
+	AActor* SpawnItem(TSubclassOf<AActor> ItemClass);
 protected:
 
 	UPROPERTY(VisibleAnywhere, BlueprintReadOnly, Category = "Spawn Volume")
@@ -27,8 +28,6 @@ protected:
 
 	UPROPERTY(EditAnywhere, BlueprintReadOnly, Category = "Spawn Volume")
 	UDataTable* ItemDataTable;
-
-	AActor* SpawnItem(TSubclassOf<AActor> ItemClass);
 	
 	FVector GetRandomPointInVolume() const;
 	

--- a/Source/Project8/Public/Spike.h
+++ b/Source/Project8/Public/Spike.h
@@ -1,0 +1,46 @@
+#pragma once
+
+#include "CoreMinimal.h"
+#include "ItemBase.h"
+#include "Spike.generated.h"
+
+class USphereComponent;
+
+UCLASS()
+class PROJECT8_API ASpike : public AItemBase
+{
+	GENERATED_BODY()
+	
+public:
+	ASpike();
+
+protected:
+	UPROPERTY(VisibleAnywhere, BlueprintReadOnly, Category = "Item|Component")
+	USphereComponent* DamageCollision;
+	
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Mine")
+	float SpikeDelay;
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Mine")
+	float SpikeRadius;
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Mine")
+	int SpikeDamage;
+
+	virtual void OnItemEndOverlap(
+		UPrimitiveComponent* OverlappedComp,
+		AActor* OtherActor,
+		UPrimitiveComponent* OtherComp,
+		int32 OtherBodyIndex) override;
+
+	void Disappear();
+	void Appear();
+	FTimerHandle VisibleTimerHandle;
+
+	bool bIsActivating;
+	bool bIsDamaged;
+
+	float VisibleDuration;
+	float HiddenDuration;
+
+	virtual void ActivateItem(AActor* Activator) override;
+	virtual void BeginPlay() override;
+};


### PR DESCRIPTION
ItemBase 클래스를 상속받아 필드 장애물인 Spike 클래스 생성
- 해당 장애물은 각 레벨 Wave2 부터 현재 웨이브에 따른 개수 랜덤 배치
- 플레이어가 충돌하면 15 의 데미지를 입히며, 일반 아이템과는 다르게 Destroy 를 호출하지 않고 필드에 남아있음